### PR TITLE
Fix character creation and chat input lag

### DIFF
--- a/app/assets/stylesheets/components/_chatbox.scss
+++ b/app/assets/stylesheets/components/_chatbox.scss
@@ -36,9 +36,7 @@
 	width: 100%;
 	padding: 10px;
 	padding-right: 80px;
-	backdrop-filter: blur(16px) saturate(180%);
-	-webkit-backdrop-filter: blur(16px) saturate(180%);
-	background-color: #0e1328be;
+	background-color: #0e1328e6;
 	color: #fff;
 	border-radius: 15px;
 	border: 1px solid #1a2038;

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -15,6 +15,8 @@ class Character < ApplicationRecord
   validates :name, :level, :race, :character_class, :max_hp, :current_hp, :armor_class, :equipment, presence: true
 
     def set_image_path
+      return unless self.race && self.character_class && self.gender.present?
+
       image_lookup = {
         "male_tiefling_warlock" => "male_tiefling_warlock.png",
         "female_tiefling_warlock" => "female_tiefling_warlock.png",
@@ -45,8 +47,7 @@ class Character < ApplicationRecord
   private
 
   def set_class_defaults
-
-    stats_values = {}
+    return unless self.character_class
 
     case self.character_class.name.downcase
     when 'cleric'
@@ -76,6 +77,8 @@ class Character < ApplicationRecord
   end
 
   def stats_defaults
+    return {} unless self.character_class
+
     case self.character_class.name.downcase
 
     when 'cleric'

--- a/app/views/characters/new.html.erb
+++ b/app/views/characters/new.html.erb
@@ -217,7 +217,7 @@ submitButton.addEventListener('click', function () {
 </script>
 
 <script>
-document.addEventListener("DOMContentLoaded", function() {
+document.addEventListener("turbo:load", function() {
   // For character classes
   document.querySelectorAll('.character-class-button').forEach(function(button) {
     button.addEventListener('click', function(e) {


### PR DESCRIPTION
## Summary

- Guard `set_image_path`, `set_class_defaults`, and `stats_defaults` against nil race/class so submitting the form with empty fields shows validation errors instead of crashing
- Fix race/class/gender selection buttons not responding on Turbo navigation (`DOMContentLoaded` → `turbo:load`)
- Remove `backdrop-filter: blur()` from chat input — was causing typing lag by forcing GPU compositing over the WebGL canvas on every keypress

## Test plan

- [ ] Submit character creation form with empty fields — should show validation errors, not 500
- [ ] Select race, class, and gender on the new character form — buttons should highlight and submit correctly
- [ ] Type in the chat input on the session page — should feel immediate

🤖 Generated with [Claude Code](https://claude.com/claude-code)